### PR TITLE
Support Multiple projects per channel

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
         'Bot::BasicBot::Pluggable::Module' => 0,
         'Net::GitHub::V2' => 0,
         'YAML'            => 0,
-        'LWP::Simple'     => 0,
+        'LWP::UserAgent'  => 0,
         'JSON'            => 0,
         'URI::Title'      => 0,
     },

--- a/lib/Bot/BasicBot/Pluggable/Module/GitHub/EasyLinks.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/GitHub/EasyLinks.pm
@@ -37,6 +37,8 @@ sub said {
     while ($mess->{body} =~ m{ 
         (?:  
             \b
+            # Term to search for in project names
+            (?<search> \S+ )? \s*
             # "Issue 42", "PR 42" or "Pull Request 42"
             (?<thing> (?:issue|gh|pr|pull request) ) 
             (?:\s+|-)?
@@ -52,6 +54,10 @@ sub said {
 
         my $project = $+{project} || $self->github_project($mess->{channel});
         return unless $project;
+
+        # Search through all the projects to see if the search word matches
+        $project = $self->search_projects($mess->{channel}, $+{search}) 
+                        || $project;
 
         # Get the Net::GitHub::V2 object we'll be using.  (If we don't get one,
         # for some reason, we can't do anything useful.)

--- a/lib/Bot/BasicBot/Pluggable/Module/GitHub/PullRequests.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/GitHub/PullRequests.pm
@@ -37,7 +37,7 @@ sub said {
         return unless $project;
 
         # Search through all the projects to see if the search word matches
-        my $project = $self->search_projects($mess->{channel}, $search)
+        $project = $self->search_projects($mess->{channel}, $search)
                             || $project;
 
         if (!$project) {

--- a/lib/Bot/BasicBot/Pluggable/Module/GitHub/PullRequests.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/GitHub/PullRequests.pm
@@ -7,7 +7,6 @@ package Bot::BasicBot::Pluggable::Module::GitHub::PullRequests;
 use strict;
 use Bot::BasicBot::Pluggable::Module::GitHub;
 use base 'Bot::BasicBot::Pluggable::Module::GitHub';
-use LWP::Simple ();
 use LWP::UserAgent;
 use JSON;
 

--- a/t/01-parse-config.t
+++ b/t/01-parse-config.t
@@ -19,6 +19,11 @@ sub get {
     return unless $namespace eq 'GitHub';
     return $self->{settings}{$key};
 }
+sub set {
+    my ($self, $namespace, $key, $value) = @_;
+    return unless $namespace eq 'GitHub';
+    $self->{settings}{$key} = $value;
+}
 
 
 # Subclass to override fetching of config setting from store
@@ -40,7 +45,7 @@ use Bot::BasicBot::Pluggable::Module::GitHub;
 
 
 package main;
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 my $plugin = MockBot->new;
 
@@ -77,3 +82,9 @@ is($plugin->auth_for_project('fake/project'), undef,
     'Got undef auth info for non-configured project'
 );
 
+# Test default_auth if set
+$plugin->{_store}->set('GitHub', 'default_auth', 'default:auth');
+
+is($plugin->auth_for_project('someuser/foo'), 'default:auth',
+    'Got expected default auth info for a project'
+);

--- a/t/01-parse-config.t
+++ b/t/01-parse-config.t
@@ -40,15 +40,15 @@ use Bot::BasicBot::Pluggable::Module::GitHub;
 
 
 package main;
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 my $plugin = MockBot->new;
 
 # Set some projects for channels, then we can test we get the right info back
 $plugin->{_store} = MockStore->new({
-    project_for_channel => {
-        '#foo' => 'someuser/foo',
-        '#bar' => 'bobby/tables',
+    projects_for_channel => {
+        '#foo' =>  [ 'someuser/foo' ],
+        '#bar' => [ 'bobby/tables', 'tom/drinks' ] ,
     },
     auth_for_project => {
         'bobby/tables' => 'bobby:tables',
@@ -57,11 +57,16 @@ $plugin->{_store} = MockStore->new({
 
 
 
-is($plugin->project_for_channel('#foo'), 'someuser/foo',
+is_deeply ($plugin->projects_for_channel('#foo'), [ 'someuser/foo' ],
     'Got expected project for a channel'
 );
 
-is($plugin->project_for_channel('#fake'), undef,
+is_deeply ($plugin->projects_for_channel('#bar'),
+    [ 'bobby/tables', 'tom/drinks' ],
+    'Got expected projects for a channel'
+);
+
+is($plugin->projects_for_channel('#fake'), undef,
     'Got undef project for non-configured channel'
 );
 


### PR DESCRIPTION
This adds support for multiple projects per channel.  For now, the first channel is the primary/default.

I've moved `!setgithubproject` ->  `!setgithubprojects` and added `!addgithubproject <channel> <project>` as well as `!deletegithubproject <channel> <project>`.

For auth, I've added `!setauthforproject <project> <auth>` (not sure if this should have 'github' somewhere in the command name?), as well as `!setdefaultauth <auth>` which will set a global auth default for anything without a specific auth set (very useful for me as I add many projects but all can use the same auth).

To facilitate multiple repos with issues/prs, i've updated EasyLinks.pm to use the following:

If you just type `issue 42` you will get the issue for the default project (the first one added to that channel).  If there are other projects, you can do `api issue 42` and it will search through all your projects for the first one that matches 'api' and use that one.  If none are found to match, it reverts back to the default again.  The same happens with !pr.  This makes it so that with !pr you don't have to type the full project name.

I've also made !pr support authenticated requests using the same auth_for_project and auth_default parameters as everything else.  This does replace the LWP::Simple requirement with LWP::UserAgent (updated in the makefile).

I'd love some comments and feedback.  Thanks!
